### PR TITLE
Typo fix, and suggestion to fix build issue under 64-bits machine.

### DIFF
--- a/Lecture1/function_call.c
+++ b/Lecture1/function_call.c
@@ -1,6 +1,7 @@
 /*
 Understand how the fucntion call look like in assembly.
-gcc -m32 function_call.c -o fucntion_call -fno-stack-protector
+gcc -m32 function_call.c -o function_call -fno-stack-protector
+When running under 64-bits machine, use '-m64' instead of '-m32'.
 */
 
 #include <stdio.h>
@@ -15,4 +16,3 @@ int main(){
 	foo();
 	return 0;
 }
-


### PR DESCRIPTION
- Fixed a typo in the gcc build command: `fucntion_call` -> `function_call`.
- Adding a suggestion to resolve the error when running this line under 64-bits machine.